### PR TITLE
Fix linting errors in dbl.js

### DIFF
--- a/dbl.js
+++ b/dbl.js
@@ -10,29 +10,27 @@ let dbl = function(n) {
   } else {
     return n * 2;
   }
-}
+};
 
 //function to double an input of any basic type
 let trpl = function(n) {
   if (typeof n === 'undefined') {
     return undefined;
-  } elseif (typeof n === 'string') {
+  } else if (typeof n === 'string') {
     return n + n;
   } else {
     return n * 3;
   }
-}
+};
 
 //Example pieces of code that may be needed when making my FYP
 let processSingleJob = function (job) {
-  job.getResults().then(
-    display();
-  )
+  job.getResults().then(display);
 };
 
 let processJobs = function (jobList) {
-  jobsList.forEach(processSingleJob);
-}
+  jobList.forEach(processSingleJob);
+};
 
 request('/selenium/jobs')
   .then(processJobs)


### PR DESCRIPTION
- `elseif` is not a valid keyword, use `else if`
- Semicolons are needed after `let x = function() {..};` as it is an expression
